### PR TITLE
add sql-like query strings for more convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ Following values can be used for the operator. If none is provided, it assumes "
 
 [Read more about filter in Drupal.org Documentation](https://www.drupal.org/docs/8/core/modules/jsonapi-module/filtering)
 
+### addFilterQuery
+
+Used to add filter queries in an SQL-like string format.
+
+| Params | Type | Description |
+| ---   | ---  | ---         |
+| query     | `string` | A query string representing a single filter (format: "\<path\> \<operator\> '\<value\>' \<memberOf\> \<groupName\>").
+
+#### usage example
+
+```js
+import {DrupalJsonApiParams} from 'drupal-jsonapi-params';
+
+const apiParams = new DrupalJsonApiParams();
+
+apiParams.addFilterQuery("pet = 'cat' memberOf animals")
+```
+
+
 ### addGroup
 
 Used to group Filters. Groups can be nested too.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import qs = require('qs');
+import Operators from './Operators.ts'
 
 interface FilterItems {
   [key: string]: FilterItem | string;
@@ -121,6 +122,17 @@ export class DrupalJsonApiParams {
     };
 
     return this;
+  }
+  
+  public addFilterQuery(query: string): DrupalJsonApiParams {
+    const operators = Object.values(Operators).join('|');
+    const re = new RegExp(`(?<path>.+)\s*(?<operator>${operators})\s*'(?<value>.+)'\s*((memberOf)\s*(?<memberOf>.+))?`);
+    const matches = query.match(re);
+    let { path, operator, value, memberOf } = matches.groups;
+    value = JSON.parse(value);
+    memberOf = memberOf ? [memberOf] : []; 
+    const params = [path, operator, value, ...memberOf];
+    return this.addFilter(...params);
   }
 
   private getIndexId(obj: any, proposedKey: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import qs = require('qs');
-import Operators from './Operators.ts'
+import Operators from './operators.ts'
 
 interface FilterItems {
   [key: string]: FilterItem | string;


### PR DESCRIPTION
This implements a method allowing filters to be constructed from query strings.

It should mainly be more convenient and quicker to type for less complex filters.

Query strings can be written like so:

```
apiParams.addFilterQuery("pet = 'cat'")
apiParams.addFilterQuery("name CONTAINS 'Jo' memberOf first-name")

```