### PR TITLE
Add options to getQueryString(options)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,15 @@ apiParams
   .addSort('status');
 
 const urlencodedQueryString = apiParams.getQueryString();
+const queryString = apiParams.getQueryString({ encode: false });
 
 ```
 
 ## API
 
-### getQueryString
+### getQueryString [options?]
 
-Returns urlencoded query string which can be used in api calls.
+Returns query string which can be used in api calls. By default the output is URI encoded. Options can be passed to control the [qs.stringifying](https://github.com/ljharb/qs#stringifying) internally used.
 
 ### addFilter
 

--- a/src/__tests__/DefaultValues.test.ts
+++ b/src/__tests__/DefaultValues.test.ts
@@ -7,13 +7,13 @@ test('Empty Default Values', () => {
 test('Filter for `status = 1`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', '1');
-  expect(decodeURIComponent(api.getQueryString())).toBe('filter[status]=1');
+  expect(api.getQueryString({ encode: false })).toBe('filter[status]=1');
 });
 
 test('Filter for `status = 1` && `status = 2`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', '1').addFilter('status', '2');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[1][condition][path]=status&filter[1][condition][value]=2&filter[status]=1',
   );
 });
@@ -35,14 +35,14 @@ test('Filter for `status = [1, 20]`', () => {
 test('Filter for `status IS NULL`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', null, 'IS NULL');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[status][condition][path]=status&filter[status][condition][operator]=IS NULL',
   );
 });
 test('Filter for `status IS NULL` in valid', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', null, 'IS NULL', 'valid');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[status][condition][path]=status&filter[status][condition][operator]=IS NULL&filter[status][condition][memberOf]=valid',
   );
 });
@@ -50,7 +50,7 @@ test('Filter for `status IS NULL` in valid', () => {
 test('Filter for `status IS NOT NULL`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', null, 'IS NOT NULL');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[status][condition][path]=status&filter[status][condition][operator]=IS NOT NULL',
   );
 });
@@ -58,7 +58,7 @@ test('Filter for `status IS NOT NULL`', () => {
 test('Filter for `changed is BETWEEN 0 AND 123456789`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('changed', ['0', '123456789'], 'BETWEEN');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[changed][condition][path]=changed&filter[changed][condition][value][0]=0&filter[changed][condition][value][1]=123456789&filter[changed][condition][operator]=BETWEEN',
   );
 });
@@ -66,7 +66,7 @@ test('Filter for `changed is BETWEEN 0 AND 123456789`', () => {
 test('Filter for `changed is BETWEEN 0 AND 123456789` in range', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('changed', ['0', '123456789'], 'BETWEEN', 'range');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[changed][condition][path]=changed&filter[changed][condition][value][0]=0&filter[changed][condition][value][1]=123456789&filter[changed][condition][operator]=BETWEEN&filter[changed][condition][memberOf]=range',
   );
 });
@@ -88,7 +88,7 @@ test('Filter for `changed is BETWEEN 0` in range', () => {
 test('Filter for `changed is NOT BETWEEN 0 AND 123456789`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('changed', ['0', '123456789'], 'NOT BETWEEN');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[changed][condition][path]=changed&filter[changed][condition][value][0]=0&filter[changed][condition][value][1]=123456789&filter[changed][condition][operator]=NOT BETWEEN',
   );
 });
@@ -96,7 +96,7 @@ test('Filter for `changed is NOT BETWEEN 0 AND 123456789`', () => {
 test('Filter for `id IN ["1", "2", "3"]`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('id', ['1', '2', '3'], 'IN');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[id][condition][path]=id&filter[id][condition][value][0]=1&filter[id][condition][value][1]=2&filter[id][condition][value][2]=3&filter[id][condition][operator]=IN',
   );
 });
@@ -107,7 +107,7 @@ test('Filter for `status = 1` && `status != 2` in group=publish_status', () => {
     .addGroup('publish_status')
     .addFilter('status', '1', '=', 'publish_status')
     .addFilter('status', '2', '!=', 'publish_status');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[2][condition][path]=status&filter[2][condition][value]=2&filter[2][condition][operator]=!=&filter[2][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[status][condition][path]=status&filter[status][condition][value]=1&filter[status][condition][memberOf]=publish_status',
   );
 });
@@ -115,7 +115,7 @@ test('Filter for `status = 1` && `status != 2` in group=publish_status', () => {
 test('Add Group for `status = 1` in group publish_status', () => {
   let api = new DrupalJsonApiParams();
   api.addGroup('publish_status').addFilter('status', '1', '=', 'publish_status');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[publish_status][group][conjunction]=OR&filter[status][condition][path]=status&filter[status][condition][value]=1&filter[status][condition][memberOf]=publish_status',
   );
 });
@@ -126,7 +126,7 @@ test('Add Groups to Group', () => {
     .addGroup('child_group_A', 'OR', 'parent_group')
     .addGroup('child_group_B', 'AND', 'parent_group')
     .addGroup('parent_group', 'AND');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[child_group_A][group][conjunction]=OR&filter[child_group_A][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND',
   );
 });
@@ -134,13 +134,13 @@ test('Add Groups to Group', () => {
 test('Add Include', () => {
   let api = new DrupalJsonApiParams();
   api.addInclude(['field_a.id', 'field_b.uid', 'field_c.tid']);
-  expect(decodeURIComponent(api.getQueryString())).toBe('include=field_a.id,field_b.uid,field_c.tid');
+  expect(api.getQueryString({ encode: false })).toBe('include=field_a.id,field_b.uid,field_c.tid');
 });
 
 test('Add Fields', () => {
   let api = new DrupalJsonApiParams();
   api.addFields('node--article', ['field_a.id', 'field_b.uid', 'field_c.tid']).addFields('node--blog', ['a', 'b', 'c']);
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'fields[node--article]=field_a.id,field_b.uid,field_c.tid&fields[node--blog]=a,b,c',
   );
 });
@@ -148,19 +148,19 @@ test('Add Fields', () => {
 test('Add Pager with limit 5', () => {
   let api = new DrupalJsonApiParams();
   api.addPageLimit(5);
-  expect(decodeURIComponent(api.getQueryString())).toBe('page[limit]=5');
+  expect(api.getQueryString({ encode: false })).toBe('page[limit]=5');
 });
 
 test('Add sort by status', () => {
   let api = new DrupalJsonApiParams();
   api.addSort('status');
-  expect(decodeURIComponent(api.getQueryString())).toBe('sort=status');
+  expect(api.getQueryString({ encode: false })).toBe('sort=status');
 });
 
 test('Add sort by status DESC', () => {
   let api = new DrupalJsonApiParams();
   api.addSort('status', 'DESC');
-  expect(decodeURIComponent(api.getQueryString())).toBe('sort=-status');
+  expect(api.getQueryString({ encode: false })).toBe('sort=-status');
 });
 
 test('Add multiple sort criterion', () => {
@@ -169,7 +169,7 @@ test('Add multiple sort criterion', () => {
     .addSort('id', 'DESC')
     .addSort('uid')
     .addSort('status');
-  expect(decodeURIComponent(api.getQueryString())).toBe('sort=-id,uid,status');
+  expect(api.getQueryString({ encode: false })).toBe('sort=-id,uid,status');
 });
 
 test("Nova's Ark", () => {
@@ -193,7 +193,7 @@ test("Nova's Ark", () => {
     .addSort('id', 'DESC')
     .addSort('uid')
     .addSort('status');
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[4][condition][path]=status&filter[4][condition][value]=2&filter[4][condition][operator]=!=&filter[4][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[publish_status][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND&filter[status]=1&include=field_a.id,field_b.uid,field_c.tid&page[limit]=5&sort=-id,uid,status&fields[node--article]=field_a.id,field_b.uid,field_c.tid',
   );
 });

--- a/src/__tests__/PackUnpackObject.test.ts
+++ b/src/__tests__/PackUnpackObject.test.ts
@@ -4,22 +4,22 @@ test('Empty Default Values', () => {
   let obj = api.getQueryObject();
   expect(api.getQueryString()).toBe('');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryObject(obj);
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryObject({});
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
 });
 
 test('Filter for `status = 1`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', '1');
   let obj = api.getQueryObject();
-  expect(decodeURIComponent(api.getQueryString())).toBe('filter[status]=1');
+  expect(api.getQueryString({ encode: false })).toBe('filter[status]=1');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryObject(obj);
-  expect(decodeURIComponent(api.getQueryString())).toBe('filter[status]=1');
+  expect(api.getQueryString({ encode: false })).toBe('filter[status]=1');
 });
 
 test("Nova's Ark", () => {
@@ -44,7 +44,7 @@ test("Nova's Ark", () => {
     .addSort('uid')
     .addSort('status');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api
     // Add Group within Groups.
     .addGroup('publish_status', 'OR', 'parent_group')
@@ -65,13 +65,13 @@ test("Nova's Ark", () => {
     .addSort('uid')
     .addSort('status');
   let obj = api.getQueryObject();
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[4][condition][path]=status&filter[4][condition][value]=2&filter[4][condition][operator]=!=&filter[4][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[publish_status][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND&filter[status]=1&include=field_a.id,field_b.uid,field_c.tid&page[limit]=5&sort=-id,uid,status&fields[node--article]=field_a.id,field_b.uid,field_c.tid',
   );
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryObject(obj);
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[4][condition][path]=status&filter[4][condition][value]=2&filter[4][condition][operator]=!=&filter[4][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[publish_status][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND&filter[status]=1&include=field_a.id,field_b.uid,field_c.tid&page[limit]=5&sort=-id,uid,status&fields[node--article]=field_a.id,field_b.uid,field_c.tid',
   );
 });

--- a/src/__tests__/PackUnpackString.test.ts
+++ b/src/__tests__/PackUnpackString.test.ts
@@ -4,22 +4,29 @@ test('Empty Default Values', () => {
   let queryString = api.getQueryString();
   expect(api.getQueryString()).toBe('');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryString(queryString);
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryString('');
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
 });
 
 test('Filter for `status = 1`', () => {
   let api = new DrupalJsonApiParams();
   api.addFilter('status', '1');
   let queryString = api.getQueryString();
-  expect(decodeURIComponent(api.getQueryString())).toBe('filter[status]=1');
+  expect(api.getQueryString({ encode: false })).toBe('filter[status]=1');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryString(queryString);
-  expect(decodeURIComponent(api.getQueryString())).toBe('filter[status]=1');
+  expect(api.getQueryString({ encode: false })).toBe('filter[status]=1');
+});
+
+test('Filter for `text = "\\/ []&?"` URI encoded', () => {
+  let api = new DrupalJsonApiParams();
+  api.addFilter('text', `\/ []&?`);
+  let queryString = api.getQueryString();
+  expect(api.getQueryString()).toBe(`filter%5Btext%5D=%2F%20%5B%5D%26%3F`);
 });
 
 test("Nova's Ark", () => {
@@ -44,7 +51,7 @@ test("Nova's Ark", () => {
     .addSort('uid')
     .addSort('status');
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api
     // Add Group within Groups.
     .addGroup('publish_status', 'OR', 'parent_group')
@@ -65,13 +72,13 @@ test("Nova's Ark", () => {
     .addSort('uid')
     .addSort('status');
   let queryString = api.getQueryString();
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[4][condition][path]=status&filter[4][condition][value]=2&filter[4][condition][operator]=!=&filter[4][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[publish_status][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND&filter[status]=1&include=field_a.id,field_b.uid,field_c.tid&page[limit]=5&sort=-id,uid,status&fields[node--article]=field_a.id,field_b.uid,field_c.tid',
   );
   api.clear();
-  expect(decodeURIComponent(api.getQueryString())).toBe('');
+  expect(api.getQueryString()).toBe('');
   api.initializeWithQueryString(queryString);
-  expect(decodeURIComponent(api.getQueryString())).toBe(
+  expect(api.getQueryString({ encode: false })).toBe(
     'filter[4][condition][path]=status&filter[4][condition][value]=2&filter[4][condition][operator]=!=&filter[4][condition][memberOf]=publish_status&filter[publish_status][group][conjunction]=OR&filter[publish_status][group][memberOf]=parent_group&filter[child_group_B][group][conjunction]=AND&filter[child_group_B][group][memberOf]=parent_group&filter[parent_group][group][conjunction]=AND&filter[status]=1&include=field_a.id,field_b.uid,field_c.tid&page[limit]=5&sort=-id,uid,status&fields[node--article]=field_a.id,field_b.uid,field_c.tid',
   );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,9 +164,9 @@ export class DrupalJsonApiParams {
     return data;
   }
 
-  public getQueryString(): string {
+  public getQueryString(options?: object): string {
     const data = this.getQueryObject();
-    return qs.stringify(data);
+    return qs.stringify(data, options);
   }
 
   public clear() {


### PR DESCRIPTION
Pass on the options to [qs.stringify](https://github.com/ljharb/qs#stringifying)

This is not breaking since it's optional and the default behaviour is not changed. `MINOR` in [Semantic Versioning](https://semver.org/)

I refactored all the test to not include the encoding and add an additional encoding test if no options are passed to the function ( see → `Filter for text = "\/ []&?" URI encoded` in `src/__tests__/PackUnpackString.test.ts`)