### PR TITLE
handle operators IS NULL and IS NOT NULL appropriately.

### DIFF
--- a/src/__tests__/Shortner.test.ts
+++ b/src/__tests__/Shortner.test.ts
@@ -99,3 +99,18 @@ test('10. Filtering on Date (Date only, no time)', () => {
   api.addFilter('created', '448365617');
   expect(api.getQueryString({ encode: false })).toBe('filter[created]=448365617');
 });
+
+test('11. Dont shorten IS NULL or IS NOT NULL', () => {
+  // see https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module/filtering
+  let api = new DrupalJsonApiParams();
+
+  api.addFilter('field_test_date', null, 'IS NULL');
+  expect(api.getQueryString({ encode: false })).toBe('filter[field_test_date][condition][path]=field_test_date&filter[field_test_date][condition][operator]=IS NULL');
+
+  api.clear();
+
+  api.addFilter('field_test_date', null, 'IS NOT NULL');
+  expect(api.getQueryString({ encode: false })).toBe('filter[field_test_date][condition][path]=field_test_date&filter[field_test_date][condition][operator]=IS NOT NULL');
+
+  api.clear();
+});


### PR DESCRIPTION
I've seen and experienced some errors with the shorthand logic and null operators. An error is thrown when trying to use the 'IS NULL' or 'IS NOT NULL' operators with the shorthand notation. This may be the case with other operators but I know of these two for now. I think this addresses the issue.

See https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module/filtering in reference to the nullish examples. They specifically require the longform and not the shorthand.